### PR TITLE
feat: Add RetryInfo message to error_details.proto

### DIFF
--- a/proto/example/v1/error_details.proto
+++ b/proto/example/v1/error_details.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package example.v1;
+
+message RetryInfo {
+    string count = 1;
+}


### PR DESCRIPTION
Add a new message RetryInfo to handle retry info in the error_details.proto. This message has one field - count of type string, to determine the retry count. The syntax is updated to proto3 and it belongs to the example.v1 package.